### PR TITLE
Updated bower.json file to remove spaces from name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-   "name": "jQuery Nice Select",
+   "name": "jquery-nice-select",
    "authors": [
       "Hernán Sartorio <hello@hernansartorio.com>"
    ],


### PR DESCRIPTION
Usually bower package names don't have spaces in them because when bower creates the new folders in the components folder it uses the name in the bower.json file for the name of the folder. If there are names in the package name, then there will be names in the folder name, which is annoying.