### PR TITLE
Selected option retains html tags

### DIFF
--- a/js/jquery.nice-select.js
+++ b/js/jquery.nice-select.js
@@ -120,8 +120,8 @@
       $dropdown.find('.selected').removeClass('selected');
       $option.addClass('selected');
       
-      var text = $option.data('display') || $option.text();
-      $dropdown.find('.current').text(text);
+      var html = $option.data('display') || $option.html();
+      $dropdown.find('.current').html(html);
       
       $dropdown.prev('select').val($option.data('value')).trigger('change');
     });


### PR DESCRIPTION
The initially selected options retain the HTML tags, once you select a different option it removes the HTML tags from the selected option and just copies the text inside the tags by using the `text()` method. So, I have changed `text()` method to `html()`.